### PR TITLE
this should fix #4 and #7; POST and GET requests now work for me anyway

### DIFF
--- a/src/bookstack/models.py
+++ b/src/bookstack/models.py
@@ -53,11 +53,10 @@ class BookStack:
                     del arg[0]["id"]
                 except:
                     pass
-            response = self._session.request(method_info['method'], uri.format(arg))
             if method_info['method'] == "POST" or method_info['method'] == "PUT":
-                self._session.request(method_info['method'], uri, json=arg[0])
+                response = self._session.request(method_info['method'], uri, json=arg[0])
             else:
-                self._session.request(method_info['method'], uri.format(arg))
+                response = self._session.request(method_info['method'], uri.format(arg))
             return self._get_response_content(response)
         return request_method
 


### PR DESCRIPTION
Seems like the code in the repo is the result of a bad merge or something.  Looks like the intention was to remove the first call to self._session.request and split it for POST/PUT vs. other methods.

However, the first call was left in place; this generates the missing name error because the response from the 2nd call was ignored.